### PR TITLE
Add benchmarks for sorting small and large tables

### DIFF
--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -23,7 +23,7 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
   }
 
  protected:
-  void SetUpWithOverriddenSize(const ChunkOffset& chunk_size, const size_t& row_count) {
+  void SetUpWithOverriddenSize(const size_t row_count, const ChunkOffset chunk_size) {
     const auto table_generator = std::make_shared<SyntheticTableGenerator>();
 
     // We only set _table_wrapper_a because this is the only table (currently) used in the Sort Benchmarks

--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -5,18 +5,45 @@
 #include "../micro_benchmark_basic_fixture.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_wrapper.hpp"
+#include "synthetic_table_generator.hpp"
 
 namespace opossum {
 
-BENCHMARK_F(MicroBenchmarkBasicFixture, BM_Sort)(benchmark::State& state) {
-  _clear_cache();
+class SortBenchmark : public MicroBenchmarkBasicFixture {
+ public:
+  void BM_Sort(benchmark::State& state) {
+    _clear_cache();
 
-  auto warm_up = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
-  warm_up->execute();
-  for (auto _ : state) {
-    auto sort = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
-    sort->execute();
+    auto warm_up = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
+    warm_up->execute();
+    for (auto _ : state) {
+      auto sort = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
+      sort->execute();
+    }
   }
-}
+
+ protected:
+  void SetUpWithOverriddenSize(const ChunkOffset& chunk_size, const size_t& row_count) {
+    const auto table_generator = std::make_shared<SyntheticTableGenerator>();
+
+    // We only set _table_wrapper_a because this is the only table (currently) used in the Sort Benchmarks
+    _table_wrapper_a = std::make_shared<TableWrapper>(table_generator->generate_table(2ul, row_count, chunk_size));
+    _table_wrapper_a->execute();
+  }
+};
+
+class SortSmallBenchmark : public SortBenchmark {
+ public:
+  void SetUp(benchmark::State& st) override { SetUpWithOverriddenSize(ChunkOffset{200}, size_t{4'000}); }
+};
+
+class SortLargeBenchmark : public SortBenchmark {
+ public:
+  void SetUp(benchmark::State& st) override { SetUpWithOverriddenSize(ChunkOffset{20'000}, size_t{400'000}); }
+};
+
+BENCHMARK_F(SortBenchmark, BM_Sort)(benchmark::State& state) { BM_Sort(state); }
+BENCHMARK_F(SortSmallBenchmark, BM_SortSmall)(benchmark::State& state) { BM_Sort(state); }
+BENCHMARK_F(SortLargeBenchmark, BM_SortLarge)(benchmark::State& state) { BM_Sort(state); }
 
 }  // namespace opossum


### PR DESCRIPTION
Closes #1

#### Results:
```
Bastian.Koenig@vm-appleton:~/hyrise$ cmake-build-release/hyriseMicroBenchmarks --benchmark_filter=BM_Sort*
2019-12-02 21:30:57
Running cmake-build-release/hyriseMicroBenchmarks
Run on (32 X 2500 MHz CPU s)
CPU Caches:
  L1 Data 32K (x32)
  L1 Instruction 32K (x32)
  L2 Unified 256K (x32)
  L3 Unified 25600K (x32)
Load Average: 0.10, 2.57, 2.70
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
SortBenchmark/BM_Sort             12325238 ns     12318297 ns           58
SortSmallBenchmark/BM_SortSmall    1569928 ns      1567021 ns          369
SortLargeBenchmark/BM_SortLarge  142397451 ns    142382962 ns            5
```