### PR TITLE
Reorder GenerateCustomTable (switch row_count and chunk_size) in Sort MicroBenchmark

### DIFF
--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -184,32 +184,34 @@ class SortNullBenchmark : public SortBenchmark {
   }
 };
 
-BENCHMARK_F(SortBenchmark, BM_Sort)(benchmark::State& state) { BM_Sort(state); }
-
-BENCHMARK_F(SortBenchmark, BM_SortSingleColumnSQL)(benchmark::State& state) { BM_SortSingleColumnSQL(state); }
-
-BENCHMARK_F(SortBenchmark, BM_SortMultiColumnSQL)(benchmark::State& state) { BM_SortMultiColumnSQL(state); }
 
 BENCHMARK_F(SortPicoBenchmark, BM_SortPico)(benchmark::State& state) { BM_Sort(state); }
 
 BENCHMARK_F(SortSmallBenchmark, BM_SortSmall)(benchmark::State& state) { BM_Sort(state); }
 
-BENCHMARK_F(SortLargeBenchmark, BM_SortLarge)(benchmark::State& state) { BM_Sort(state); }
+BENCHMARK_F(SortBenchmark, BM_Sort)(benchmark::State& state) { BM_Sort(state); }
 
-BENCHMARK_F(SortReferenceBenchmark, BM_SortReference)(benchmark::State& state) { BM_Sort(state); }
+BENCHMARK_F(SortLargeBenchmark, BM_SortLarge)(benchmark::State& state) { BM_Sort(state); }
 
 BENCHMARK_F(SortReferencePicoBenchmark, BM_SortReferencePico)(benchmark::State& state) { BM_Sort(state); }
 
 BENCHMARK_F(SortReferenceSmallBenchmark, BM_SortReferenceSmall)(benchmark::State& state) { BM_Sort(state); }
 
+BENCHMARK_F(SortReferenceBenchmark, BM_SortReference)(benchmark::State& state) { BM_Sort(state); }
+
 BENCHMARK_F(SortReferenceLargeBenchmark, BM_SortReferenceLarge)(benchmark::State& state) { BM_Sort(state); }
 
-BENCHMARK_F(SortStringBenchmark, BM_SortString)(benchmark::State& state) { BM_Sort(state); }
-
 BENCHMARK_F(SortStringSmallBenchmark, BM_SortStringSmall)(benchmark::State& state) { BM_Sort(state); }
+
+BENCHMARK_F(SortStringBenchmark, BM_SortString)(benchmark::State& state) { BM_Sort(state); }
 
 BENCHMARK_F(SortStringLargeBenchmark, BM_SortStringLarge)(benchmark::State& state) { BM_Sort(state); }
 
 BENCHMARK_F(SortNullBenchmark, BM_SortNullBenchmark)(benchmark::State& state) { BM_Sort(state); }
+
+BENCHMARK_F(SortBenchmark, BM_SortSingleColumnSQL)(benchmark::State& state) { BM_SortSingleColumnSQL(state); }
+
+BENCHMARK_F(SortBenchmark, BM_SortMultiColumnSQL)(benchmark::State& state) { BM_SortMultiColumnSQL(state); }
+
 
 }  // namespace opossum

--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -49,7 +49,7 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
   }
 
  protected:
-  std::shared_ptr<Table> GenerateCustomTable(const size_t row_count, const ChunkOffset chunk_size,
+  std::shared_ptr<Table> GenerateCustomTable(const ChunkOffset chunk_size, const size_t row_count,
                                              const DataType data_type = DataType::Int,
                                              const std::optional<std::vector<std::string>>& column_names = std::nullopt,
                                              const std::optional<float> null_ratio = std::nullopt) {
@@ -69,13 +69,13 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
         UseMvcc::Yes, null_ratio);
   }
 
-  void InitializeCustomTableWrapper(const size_t row_count, const ChunkOffset chunk_size,
+  void InitializeCustomTableWrapper(const ChunkOffset chunk_size, const size_t row_count,
                                     const DataType data_type = DataType::Int,
                                     const std::optional<std::vector<std::string>>& column_names = std::nullopt,
                                     const std::optional<float> null_ratio = std::nullopt) {
     // We only set _table_wrapper_a because this is the only table (currently) used in the Sort Benchmarks
     _table_wrapper_a =
-        std::make_shared<TableWrapper>(GenerateCustomTable(row_count, chunk_size, data_type, column_names, null_ratio));
+        std::make_shared<TableWrapper>(GenerateCustomTable(chunk_size, row_count, data_type, column_names, null_ratio));
     _table_wrapper_a->execute();
   }
 

--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -49,7 +49,7 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
   }
 
  protected:
-  std::shared_ptr<Table> GenerateCustomTable(const ChunkOffset chunk_size, const size_t row_count,
+  std::shared_ptr<Table> GenerateCustomTable(const size_t row_count, const ChunkOffset chunk_size,
                                              const DataType data_type = DataType::Int,
                                              const std::optional<std::vector<std::string>>& column_names = std::nullopt,
                                              const std::optional<float> null_ratio = std::nullopt) {
@@ -69,13 +69,13 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
         UseMvcc::Yes, null_ratio);
   }
 
-  void InitializeCustomTableWrapper(const ChunkOffset chunk_size, const size_t row_count,
+  void InitializeCustomTableWrapper(const size_t row_count, const ChunkOffset chunk_size,
                                     const DataType data_type = DataType::Int,
                                     const std::optional<std::vector<std::string>>& column_names = std::nullopt,
                                     const std::optional<float> null_ratio = std::nullopt) {
     // We only set _table_wrapper_a because this is the only table (currently) used in the Sort Benchmarks
     _table_wrapper_a =
-        std::make_shared<TableWrapper>(GenerateCustomTable(chunk_size, row_count, data_type, column_names, null_ratio));
+        std::make_shared<TableWrapper>(GenerateCustomTable(row_count, chunk_size, data_type, column_names, null_ratio));
     _table_wrapper_a->execute();
   }
 
@@ -95,7 +95,7 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
     column_names->push_back("col_1");
     column_names->push_back("col_2");
     storage_manager.add_table("table_a",
-                              GenerateCustomTable(ChunkOffset{2'000}, size_t{40'000}, DataType::Int, column_names));
+                              GenerateCustomTable(size_t{40'000}, ChunkOffset{2'000}, DataType::Int, column_names));
 
     for (auto _ : state) {
       hsql::SQLParserResult result;
@@ -110,17 +110,17 @@ class SortBenchmark : public MicroBenchmarkBasicFixture {
 
 class SortPicoBenchmark : public SortBenchmark {
  public:
-  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{2}); }
+  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(size_t{2}, ChunkOffset{2'000}); }
 };
 
 class SortSmallBenchmark : public SortBenchmark {
  public:
-  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{4'000}); }
+  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(size_t{4'000}, ChunkOffset{2'000}); }
 };
 
 class SortLargeBenchmark : public SortBenchmark {
  public:
-  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{400'000}); }
+  void SetUp(benchmark::State& st) override { InitializeCustomTableWrapper(size_t{400'000}, ChunkOffset{2'000}); }
 };
 
 class SortReferencePicoBenchmark : public SortPicoBenchmark {
@@ -158,28 +158,28 @@ class SortReferenceLargeBenchmark : public SortLargeBenchmark {
 class SortStringSmallBenchmark : public SortBenchmark {
  public:
   void SetUp(benchmark::State& st) override {
-    InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{4'000}, DataType::String);
+    InitializeCustomTableWrapper(size_t{4'000}, ChunkOffset{2'000}, DataType::String);
   }
 };
 
 class SortStringBenchmark : public SortBenchmark {
  public:
   void SetUp(benchmark::State& st) override {
-    InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{40'000}, DataType::String);
+    InitializeCustomTableWrapper(size_t{40'000}, ChunkOffset{2'000}, DataType::String);
   }
 };
 
 class SortStringLargeBenchmark : public SortBenchmark {
  public:
   void SetUp(benchmark::State& st) override {
-    InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{400'000}, DataType::String);
+    InitializeCustomTableWrapper(size_t{400'000}, ChunkOffset{2'000}, DataType::String);
   }
 };
 
 class SortNullBenchmark : public SortBenchmark {
  public:
   void SetUp(benchmark::State& st) override {
-    InitializeCustomTableWrapper(ChunkOffset{2'000}, size_t{40'000}, DataType::Int, std::nullopt,
+    InitializeCustomTableWrapper(size_t{40'000}, ChunkOffset{2'000}, DataType::Int, std::nullopt,
                                  std::optional<float>{0.2});
   }
 };


### PR DESCRIPTION
Closes #9

``` java
Bastian.Koenig@vm-appleton:~/hyrise$ cmake-build-release/hyriseMicroBenchmarks --benchmark_filter=BM_Sort*
2020-01-12 22:11:35
Running cmake-build-release/hyriseMicroBenchmarks
Run on (32 X 2500 MHz CPU s)
CPU Caches:
  L1 Data 32K (x32)
  L1 Instruction 32K (x32)
  L2 Unified 256K (x32)
  L3 Unified 25600K (x32)
Load Average: 0.08, 0.07, 0.02
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
SortBenchmark/BM_Sort                                9927092 ns      9918420 ns           83
SortBenchmark/BM_SortSingleColumnSQL                11697463 ns     11697524 ns           60
[PERF] Multiple ORDER BYs are executed one-by-one at src/lib/logical_query_plan/lqp_translator.cpp:272
	Performance can be affected. This warning is only shown once.

SortBenchmark/BM_SortMultiColumnSQL                 25168453 ns     25168143 ns           21
SortPicoBenchmark/BM_SortPico                           3108 ns         3108 ns       224457
SortSmallBenchmark/BM_SortSmall                       708159 ns       708099 ns          860
SortLargeBenchmark/BM_SortLarge                    112134552 ns    112126522 ns            5
SortReferenceBenchmark/BM_SortReference             16079788 ns     16079781 ns           56
SortReferencePicoBenchmark/BM_SortReferencePico         3716 ns         3716 ns       194495
SortReferenceSmallBenchmark/BM_SortReferenceSmall    1045074 ns      1044611 ns          505
SortReferenceLargeBenchmark/BM_SortReferenceLarge  115130266 ns    115042670 ns            6
SortStringBenchmark/BM_SortString                   26059250 ns     26058880 ns           24
SortStringSmallBenchmark/BM_SortStringSmall          2898024 ns      2897975 ns          293
SortStringLargeBenchmark/BM_SortStringLarge        588391781 ns    588380760 ns            1
SortNullBenchmark/BM_SortNullBenchmark               7887901 ns      7887674 ns          114
```